### PR TITLE
Downgrade base to 1.4.3 for compatibility with Companion v3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "etc-eos",
-	"version": "2.0.10",
+	"version": "2.0.11",
 	"main": "main.js",
 	"scripts": {
 		"format": "prettier -w .",
@@ -12,7 +12,7 @@
 		"url": "git+https://github.com/bitfocus/companion-module-etc-eos.git"
 	},
 	"dependencies": {
-		"@companion-module/base": "~1.8.0",
+		"@companion-module/base": "~1.4.3",
 		"osc": "github:julusian/osc.js#companion-etc-eos"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Revert to companion-module-base v1.4.3 to maintain compatibility with Companion v3.0