### PR TITLE
Rework Label Polling

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,8 @@
 const { Regex } = require('@companion-module/base')
+const constants = require('./constants.js')
 
 module.exports = function (self) {
-	self.setActionDefinitions({
+	const actions = {
 		custom_cmd: {
 			name: 'Custom Command',
 			options: [
@@ -392,5 +393,28 @@ module.exports = function (self) {
 				self.sendOsc(`softkey/${key}`, arg)
 			},
 		},
-	})
+	}
+
+	// direct-select style actions	
+	for (const item_type of ['preset', 'group', 'ip', 'cp', 'fp', 'bp', 'fx', 'snap', 'ms']) {
+		const item_name = constants.ITEM_NAMES[item_type];
+		actions[`ds_${item_type}`] = {
+			name: `Select ${item_name}`,
+			options: [
+				{
+					id: item_type,
+					type: 'textinput',
+					label: item_name,
+					default: '1',
+					regex: Regex.FLOAT_OR_INT,
+					useVariables: true,
+				},
+			],
+			callback: async (event, context) => {
+				self.sendOsc(`${item_type}`, [{ type:'s', value:event.options[item_type] }])
+			},
+		}
+	}
+
+	self.setActionDefinitions(actions)
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,4 +3,59 @@ exports.DEFAULT_NUM_LABELS = 30,
 exports.NUM_SOFTKEYS = 12,
 exports.EOS_PORT = 3032,
 exports.EOS_PORT_SLIP = 3037;
-exports.LABEL_NAMES = ['group', 'preset', 'macro'];
+// this will work for most item types:
+//     cuelist, curve, fpe (fixture position estimation),
+//     pixmap,
+// will not work with:
+//     cue
+//     patch might be possible
+exports.LABEL_NAMES = [
+    'macro',
+    'sub',
+    'preset',
+    'group',
+    'ip', 'fp', 'cp', 'bp',
+    'fx', 'snap', 'ms'
+];
+
+exports.ITEM_COLOURS = {
+    macro:  0x403837,
+    sub:    0x004A26,
+    preset: 0x0A3742,
+    ip:     0x6E2A15,
+    fp:     0x003824,
+    cp:     0x31313D,
+    bp:     0x0E1A4A,
+    group:  0x364757,
+    fx:     0x36154A,
+    snap:   0x621111,
+    ms:     0x570D28,
+    scene:  0x004A26,
+    patch:  0x13202E,
+
+    
+    soft_key: 0x141414,
+    live:     0xC78B07,
+    blind:    0x82B4FF,
+};
+exports.ITEM_NAMES = {
+    macro:  "Macro",
+    sub:    "Submaster",
+    preset: "Preset",
+    ip:     "Intensity Palette",
+    fp:     "Focus Palette",
+    cp:     "Colour Palette",
+    bp:     "Beam Palette",
+    group:  "Group",
+    fx:     "Effect",
+    snap:   "Snapshot",
+    ms:     "Magic Sheet",
+    scene:  "Scene",
+
+    patch:  "Channel",
+    pixmap: "Pixel Map",
+    cuelist:"Cue List",
+    cue:    "Cue",
+    fpe:    "FPE Point",
+    curve:  "Curve",
+};

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -1,7 +1,8 @@
 const { combineRgb, Regex } = require('@companion-module/base')
+const constants = require('./constants.js')
 
 module.exports = function (self) {
-	self.setFeedbackDefinitions({
+	let feedbacks = {
 		macroisfired: {
 			type: 'boolean',
 			name: 'When macro is firing',
@@ -138,5 +139,41 @@ module.exports = function (self) {
 				return feedback.options.connected === self.instanceState['connected']
 			},
 		},
-	})
+	};
+
+	for (const item_type of constants.LABEL_NAMES) {
+		const item_name = constants.ITEM_NAMES[item_type];
+		feedbacks[`${item_type}_label`] = {
+			type: 'value',
+			name: `${item_name} Label`,
+			description: `The Label of a numbered ${item_name}.`,
+			options: [{
+				id: 'number',
+				type: 'textinput',
+				label: `${item_name} Number`,
+				default: '1',
+				regex: Regex.FLOAT_OR_INT,
+			}],
+			callback: (feedback) => {
+				let sync = self.sync;
+				self.log(
+					'debug',
+					`Eos: Feedback: ${item_name} callback called ${feedback.options.number} ${feedback.id}`
+				)
+				let v = sync.get_item_value(item_type, feedback.options.number, feedback.id);
+				self.log('debug', `Eos: Feedback: ${item_name} got value ${feedback.options.number} ${feedback.id} ${v}`)
+				return v;
+			},
+			unsubscribe: (feedback) => {
+				let sync = self.sync;
+				self.log(
+					'debug',
+					`Eos: Feedback: ${item_name} callback unsubscribed ${feedback.options.number} ${feedback.id}`
+				)
+				sync.remove_item_subscription(item_type, feedback.options.number, feedback.id);
+			},
+		};
+	}
+
+	self.setFeedbackDefinitions(feedbacks);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -808,8 +808,8 @@ class ModuleInstance extends InstanceBase {
 					if (arg.value.includes('-')) {
 						// a number range
 						// in a range all values are integers, and all values are guaranteed to exist
-						let start_num = Number(arg.value.split('-'));
-						let end_num = Number(arg.value.split('-'));
+						let start_num = Number(arg.value.split('-')[0]);
+						let end_num = Number(arg.value.split('-')[1]);
 
 						for (let item_number = start_num; item_number <= end_num; item_number++) {
 							this.sendOsc(`get/${item_type}/${item_number}`)

--- a/src/main.js
+++ b/src/main.js
@@ -85,6 +85,8 @@ class ModuleInstance extends InstanceBase {
 			this.closeOscSocket()
 			this.eos_port = this.config.use_slip ? constants.EOS_PORT_SLIP : constants.EOS_PORT
 			await this.init(config)
+		} else if (currentNumLabels !== this.getNumLabelsToPoll()) {
+			this.updateVariableDefinitions()
 		}
 	}
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const { GetVariableDefinitions, UpdateVariableDefinitions } = require('./variabl
 const UpdatePresetDefinitions = require('./presets')
 const { ParamMap } = require('./param_map')
 const constants = require('./constants.js')
+const sync = require('./sync.js')
 
 class ModuleInstance extends InstanceBase {
 	constructor(internal) {
@@ -24,6 +25,7 @@ class ModuleInstance extends InstanceBase {
 		this.eos_port = this.config.use_slip ? constants.EOS_PORT_SLIP : constants.EOS_PORT
 		this.readingWheels = false
 
+		this.sync = new sync.EosSync()
 
 		// Wheel information as module only variables, not exposed
 		this.wpc = constants.WHEELS_PER_CAT // 64
@@ -83,11 +85,6 @@ class ModuleInstance extends InstanceBase {
 			this.closeOscSocket()
 			this.eos_port = this.config.use_slip ? constants.EOS_PORT_SLIP : constants.EOS_PORT
 			await this.init(config)
-		} else if (currentNumLabels !== this.getNumLabelsToPoll()) {
-			this.updateVariableDefinitions()
-			if (this.instanceState['connected']) {
-				this.getLabelNames()
-			}
 		}
 	}
 
@@ -261,6 +258,34 @@ class ModuleInstance extends InstanceBase {
 	}
 
 	/**
+	 * Sends the path to the OSC host.
+	 *
+	 * @param path          The OSC path to send
+	 * @param args          An array of arguments, or empty if no arguments needed
+	 * @param appendPrefix  Whether to append the '/eos/' prefix to the command.
+	 */
+	sendOsc(path, args, appendPrefix) {
+		if (!this.config.host) {
+			return
+		}
+
+		if (appendPrefix !== false) {
+			path = `/eos/${path}`
+		}
+
+		let packet = {
+			address: path,
+			args: args ?? [],
+		}
+
+		if (this.debugToLogger) {
+			this.log('info', `Eos: Sending packet: ${JSON.stringify(packet)}`)
+		}
+
+		this.oscSocket.send(packet)
+	}
+
+	/**
 	 * Sets the listeners on the this.oscSocket object.
 	 *
 	 * Only needs to be done once, even if the socket reconnects.
@@ -274,29 +299,25 @@ class ModuleInstance extends InstanceBase {
 			}
 		})
 
-		const cueActive = /^\/eos\/out\/active\/cue\/([\d\.]+)\/([\d\.]+)$/
-		const cueActiveText = '/eos/out/active/cue/text'
-		const cuePending = /^\/eos\/out\/pending\/cue\/([\d\.]+)\/([\d\.]+)$/
-		const cuePendingText = '/eos/out/pending/cue/text'
-		const cuePendingOut = '/eos/out/pending/cue'
-		const cuePrevious = /^\/eos\/out\/previous\/cue\/([\d\.]+)\/([\d\.]+)$/
+		const cueActive       = /^\/eos\/out\/active\/cue\/([\d\.]+)\/([\d\.]+)$/
+		const cueActiveText   = '/eos/out/active/cue/text'
+		const cuePending      = /^\/eos\/out\/pending\/cue\/([\d\.]+)\/([\d\.]+)$/
+		const cuePendingText  = '/eos/out/pending/cue/text'
+		const cuePendingOut   = '/eos/out/pending/cue'
+		const cuePrevious     = /^\/eos\/out\/previous\/cue\/([\d\.]+)\/([\d\.]+)$/
 		const cuePreviousText = '/eos/out/previous/cue/text'
-		const cuePreviousOut = '/eos/out/previous/cue'
-		const showName = '/eos/out/show/name'
-		const version = '/eos/out/get/version'
-		const showLoaded = '/eos/out/event/show/loaded'
-		const showCleared = '/eos/out/event/show/cleared'
-		const softkey = /^\/eos\/out\/softkey\/(\d+)$/
-		const cmd = /^\/eos\/out\/user\/(\d+)\/cmd$/
-		const chan = '/eos/out/active/chan'
-		const groupNull = /^\/eos\/out\/get\/group\/([\d\.]+)$/
-		const colorhs = '/eos/out/color/hs'
-		const labels = /^\/eos\/out\/get\/(group|preset|macro)\/([\d\.]+)\/list\/([\d\.]+)\/([\d\.]+)$/
-		const labelsUpdated = /^\/eos\/out\/notify\/(group|preset|macro)\/list\/([\d\.]+)\/([\d\.]+)$/
-		const macro = /^\/eos\/out\/event\/macro\/(\d+)$/
-
-		// Maybe for later
-		// const groupChannels = /^\/eos\/out\/get\/group\/([\d\.]+)\/channels\/list\/([\d\.]+)/([\d\.]+)$/
+		const cuePreviousOut  = '/eos/out/previous/cue'
+		const showName        = '/eos/out/show/name'
+		const version         = '/eos/out/get/version'
+		const showLoaded      = '/eos/out/event/show/loaded'
+		const showCleared     = '/eos/out/event/show/cleared'
+		const softkey         = /^\/eos\/out\/softkey\/(\d+)$/
+		const cmd             = /^\/eos\/out\/user\/(\d+)\/cmd$/
+		const chan            = '/eos/out/active/chan'
+		const colorhs         = '/eos/out/color/hs'
+		const macroFired      = /^\/eos\/out\/event\/macro\/(\d+)$/
+		const syncGet         = '/eos/out/get/'
+		const syncNotify      = '/eos/out/notify/'
 
 		// This is the raw OSC message, but we are getting something parsed already...
 		// const enc_wheel      = /^\/eos\/out\/active\/wheel\/(\d+),\s*(\w+)\s*\[(\w+)\]\(s\).\s+(\d+)\(i\),\s*([\d.]*)\(f\)$/
@@ -366,33 +387,32 @@ class ModuleInstance extends InstanceBase {
 					},
 					true
 				)
-			} else if (
-				message.address === version &&
-				message.args.length === 3 &&
-				message.args[0].type === 's' &&
-				message.args[1].type === 's' &&
-				message.args[2].type === 'i'
-			) {
-				this.setInstanceStates(
-					{
-						eos_version: message.args[0].value,
-						fixture_library_version: message.args[1].value,
-						gel_swatch_type: message.args[2].value,
-					},
-					true
-				)
-			} else if (message.address === version && message.args.length === 1 && message.args[0].type === 's') {
-				this.setInstanceStates(
-					{
-						eos_version: message.args[0].value,
-						fixture_library_version: '',
-						gel_swatch_type: '',
-					},
-					true
-				)
+			} else if (message.address === version) {
+				let args = message.args;
+				if (args.length == 3 &&
+					args[0].type === 's' && args[1].type === 's' && args[2].type === 'i'
+				) {
+					this.setInstanceStates(
+						{
+							eos_version: args[0].value,
+							fixture_library_version: args[1].value,
+							gel_swatch_type: args[2].value,
+						},
+						true
+					)
+				} else if (args.length === 1 && args[0].type === 's' ) {
+					this.setInstanceStates(
+						{
+							eos_version: args[0].value,
+							fixture_library_version: '',
+							gel_swatch_type: '',
+						},
+						true
+					)
+				}
 			} else if (message.address === showLoaded || message.address === showCleared) {
 				// Reset the state when a show is loaded or a new show is created.
-				this.requestFullState()
+				this.sendConnectStart()
 			} else if (
 				(matches = message.address.match(softkey)) &&
 				message.args.length === 1 &&
@@ -414,7 +434,7 @@ class ModuleInstance extends InstanceBase {
 						true
 					)
 				}
-			} else if ((matches = message.address.match(macro))) {
+			} else if ((matches = message.address.match(macroFired))) {
 				const macroId = matches[1]
 				this.setInstanceStates(
 					{
@@ -443,65 +463,40 @@ class ModuleInstance extends InstanceBase {
 					// if channel changed, we need to get full set of wheel data
 					if (actChan != this.lastActChan) {
 						this.emptyEncVariables()
-						this.requestFullState()
+						this.requestEncData()
 						this.lastActChan = actChan
 					}
 				} else if (this.lastActChan != 0) {
 					// No channel active, clear out encoders, set lastActChan
 					// to zero so we don't keep looping on this. Initially set to -1
 					this.emptyEncVariables()
-					this.requestFullState()
+					this.requestEncData()
 					this.lastActChan = 0
 				}
-			} 
-			
-			 else if ((matches = message.address.match(labelsUpdated))) {
-				// A label was updated, request new title
-				let label_type = matches[1]
-				let label_num = Number(message.args?.[1]?.value ?? matches[3])
-				if (Number.isFinite(label_num) && label_num <= this.getNumLabelsToPoll()) {
-					let message = `/eos/get/${label_type}`
-					// this.sendOsc('/eos/get/group/index', [ { type: 'i', value: group_num } ], false)
-					this.sendOsc(message, [{ type: 'i', value: label_num }], false)
-					// this.log('info', `Eos: Need to update group info: ${JSON.stringify(group_num)}`)
-				}
-			} else if ((matches = message.address.match(labels))) {
-				let label_type = matches[1]// group, macro, preset , …
-				let label_num = matches[2]
-				this.log('info', `Eos: Capture group info: ${JSON.stringify(message)}`)
-				this.log('info', `Eos: Captured value for ${label_type} ${label_num} (${label_type}_label_${label_num}): ${message.args[2].value}`)
-				let label_string = message.args[2].value || ''
-				if (label_string) {
+			} else if (message.address.startsWith(syncGet)) {
+				this.handleSyncGet(message)
+			} else if (message.address.startsWith(syncNotify)) {
+				this.handleSyncNotify(message)
+			} else if (message.address === colorhs) {
+				let args = message.args;
+				if (args.length == 2 && args[0].type == "f" && args[1].type == "f") {
+					let hue = args[0].value.toFixed(3);
+					let sat = args[1].value.toFixed(3);
+					// this.log('debug', `HS: ${hue} ${sat}`)
 					this.setInstanceStates(
 						{
-							[`${label_type}_label_${label_num}`]: label_string,
+							hue:               hue,
+							enc_hue_floatval:  hue,
+							enc_hue_stringval: hue.toString(),
+							saturation:                 sat,
+							enc_saturation_floatval:    sat,
+							enc_saturation_stringval:   sat.toString(),
+							enc_saturationv2_floatval:  sat,
+							enc_saturationv2_stringval: sat.toString(),
 						},
 						true
 					)
 				}
-			} else if ((matches = message.address.match(groupNull))) {
-				let group_num = matches[1]
-				this.setInstanceStates(
-					{
-						[`group_label_${group_num}`]: '',
-					},
-					true
-				)
-			} else if (message.address === colorhs) {
-				// this.log('debug', `HS: ${hue} ${sat}`)
-				this.setInstanceStates(
-					{
-						hue: message.args[0].value.toFixed(3),
-						saturation: message.args[1].value.toFixed(3),
-						enc_hue_floatval: message.args[0].value.toFixed(3),
-						enc_hue_stringval: message.args[0].value.toFixed(3).toString(),
-						enc_saturation_floatval: message.args[1].value.toFixed(3),
-						enc_saturation_stringval: message.args[1].value.toFixed(3).toString(),
-						enc_saturationv2_floatval: message.args[1].value.toFixed(3),
-						enc_saturationv2_stringval: message.args[1].value.toFixed(3).toString(),
-					},
-					true
-				)
 			} else if ((matches = message.address.match(enc_wheel))) {
 				// set variables/state for wheel values
 				let wheel_num = matches[1]
@@ -570,7 +565,7 @@ class ModuleInstance extends InstanceBase {
 
 		this.oscSocket.socket.on('connect', () => {
 			this.setConnectionState(true)
-			this.requestFullState()
+			this.sendConnectStart()
 		})
 
 		// this.oscSocket.socket.on('ready', () => { })
@@ -640,24 +635,35 @@ class ModuleInstance extends InstanceBase {
 	}
 
 	/**
-	 * Request Label names from console
-	 * **/
-	getLabelNames(){
-		const numLabels = this.getNumLabelsToPoll()
-		for (let name = 0; name < constants.LABEL_NAMES.length; name++) {
-			const element = constants.LABEL_NAMES[name];
-			for (let i = 1; i <= numLabels; i++) {
-				const message = `/eos/get/${element}`
-				// this.sendOsc('/eos/get/group/index', [ { type: 'i', value: i } ], false)
-				this.sendOsc(message, [{ type: 'i', value: i }], false)
-			}
+	 * Request item counts from console
+	 **/
+	requestSubscriptionCounts() {
+		for (const item_type of constants.LABEL_NAMES) {
+			this.sendOsc(`get/${item_type}/count`)
+		}
+	}
+	
+	/**
+	 * Request Label names from console by index
+	 **/
+	requestSubscriptionItems(item_type, count) {
+		for (let i = 0; i < count; i++) {
+			this.sendOsc(`get/${item_type}/index`, [{ type: 'i', value: i }])
 		}
 	}
 
 	/**
-	 * Empties the state (variables/feedbacks) and requests the current state from the console.
+	 * Fetch data about encoders???
 	 */
-	requestFullState() {
+	requestEncData() {
+		// we don't do this actively, this happens due to subscriptions
+	}
+
+	/**
+	 * Send messages for when we have just connected,
+	 * or a new showfile has been loaded
+	 */
+	sendConnectStart() {
 		this.emptyState()
 
 		// Request the current state of the console.
@@ -669,11 +675,9 @@ class ModuleInstance extends InstanceBase {
 		// Turn on subscription for show file event updates
 		this.sendOsc('/eos/subscribe', [{ type: 'i', value: 1 }], false)
 
-		this.sendOsc('get/version', [])
+		this.sendOsc('get/version')
 
-		// Get xx groups worth of labels - issue the request here to get the values,
-		// they are caught in the on.message elsewhere
-		this.getLabelNames()
+		this.requestSubscriptionCounts()
 	}
 
 	/**
@@ -684,8 +688,138 @@ class ModuleInstance extends InstanceBase {
 		this.instanceState = {
 			connected: this.instanceState['connected'],
 		}
-
 		this.checkFeedbacks('pending_cue', 'active_cue', 'connected', 'macroisfired')
+
+		// reset sync state and recompute sync feedbacks
+		this.sync.reset()
+		let feedback_types = constants.LABEL_NAMES.map((value) => `${value}_label`);
+		this.checkFeedbacks(...feedback_types);
+	}
+
+	handleSyncGet(message) {
+		// this.log('info', `Eos: handleSyncGet ${JSON.stringify(message)}`);
+		let matches;
+
+		const count_re = /^\/eos\/out\/get\/(\w+)\/count$/;
+		if ((matches = message.address.match(count_re))) {
+			let item_type = matches[1];
+			if (!constants.LABEL_NAMES.includes(item_type))
+				// item type we don't track, just ignore
+				return;
+			
+			if (message.args.length < 1) {
+				this.log('warn', `Eos: No property value in count`)
+				return;
+			}
+			let item_count = message.args[0].value;
+			if (!item_count) {
+				this.log('warn', `Eos: Failed to parse count value: ${JSON.stringify(message)}`)
+				return;
+			}
+			item_count = Number(item_count);
+			if (!Number.isInteger(item_count)) {
+				this.log('warn', `Eos: Non-integer count value: ${JSON.stringify(message)}`)
+				return;
+			}
+
+			// this.sync.set_item_count(item_type, item_count)
+			this.requestSubscriptionItems(item_type, item_count)
+			return;
+		}
+
+		const delete_re = /^\/eos\/out\/get\/(\w+)\/(\d+(?:\.\d+)?)$/;
+		if ((matches = message.address.match(delete_re))) {
+			let item_type = matches[1];
+			let item_number = matches[2];
+			if (!constants.LABEL_NAMES.includes(item_type))
+				// item type we don't track, just ignore
+				return;
+
+			this.sync.set_item_deleted(item_type, item_number)
+
+			// legacy Variable updates
+			let num = Number(item_number)
+			if (Number.isInteger(num) && num <= this.getNumLabelsToPoll()) {
+				this.setInstanceStates({[`${item_type}_label_${item_number}`]: ''}, true);
+			}
+
+			return;
+		}
+
+		const list_re = /^\/eos\/out\/get\/(\w+)\/(\d+(?:\.\d+)?)\/list\/(\d+)\/(\d+)$/;
+		if ((matches = message.address.match(list_re))) {
+			let item_type = matches[1];
+			let item_number = matches[2];
+			let list_index = matches[3];
+			let list_count = matches[4]; // note this is total items, not for just this packet
+			if (!constants.LABEL_NAMES.includes(item_type))
+				// item type we don't track, just ignore
+				return;
+
+			this.log(
+				'info',
+				`Eos: Set item value: ${item_type} ${item_number} ${list_index} ${JSON.stringify(message.args)}`
+			)
+			let feedback_ids = this.sync.set_item_values(item_type, item_number, list_index, message.args);
+			this.checkFeedbacksById(...feedback_ids);
+
+			// legacy Variable updates
+			let num = Number(item_number)
+			if (Number.isInteger(num) && num <= this.getNumLabelsToPoll()) {
+				let label_str = sync.get_list_param(2, list_index, message.args);
+				if (label_str !== null) {
+					this.setInstanceStates({[`${item_type}_label_${item_number}`]: label_str}, true);
+				}
+			}
+
+			return;
+		}
+	}
+
+	handleSyncNotify(message) {
+		this.log('info', `Eos: handleSyncNotify ${JSON.stringify(message)}`);
+		let matches;
+
+		const notify_re = /^\/eos\/out\/notify\/(\w+)/;
+		if ((matches = message.address.match(notify_re))) {
+			let item_type = matches[1];
+			if (!constants.LABEL_NAMES.includes(item_type))
+				// item type we don't track, just ignore
+				return;
+
+			// no arguments: whole list is invalid, re-sync everything
+			if (!message.args || message.args.length == 0) {
+				this.log('info', `Eos: Whole list updated, re-syncing: ${item_type}`)
+				this.sendOsc(`get/${item_type}/count`)
+				return;
+			}
+			
+			// remove the first element (sequence number)
+			// TODO: technically this is incorrect if we aren't the first message of the list
+			message.args.shift()
+			// request data for all of the subscription items
+			for (const arg of message.args) {
+				if (arg.type == 'i') {
+					let item_number = arg.value;
+					this.sendOsc(`get/${item_type}/${item_number}`)
+				} else if (arg.type == 's') {
+					if (arg.value.includes('-')) {
+						// a number range
+						// in a range all values are integers, and all values are guaranteed to exist
+						let start_num = Number(arg.value.split('-'));
+						let end_num = Number(arg.value.split('-'));
+
+						for (let item_number = start_num; item_number <= end_num; item_number++) {
+							this.sendOsc(`get/${item_type}/${item_number}`)
+						}
+					} else {
+						// will be a decimal number - leave it as a string
+						let item_number = arg.value;
+						this.sendOsc(`get/${item_type}/${item_number}`)
+					}
+				}
+			}
+		}
 	}
 
 	/**
@@ -740,34 +874,6 @@ class ModuleInstance extends InstanceBase {
 			)
 			this.checkFeedbacks('active_cue')
 		}
-	}
-
-	/**
-	 * Sends the path to the OSC host.
-	 *
-	 * @param path          The OSC path to send
-	 * @param args          An array of arguments, or empty if no arguments needed
-	 * @param appendPrefix  Whether to append the '/eos/' prefix to the command.
-	 */
-	sendOsc(path, args, appendPrefix) {
-		if (!this.config.host) {
-			return
-		}
-
-		if (appendPrefix !== false) {
-			path = `/eos/${path}`
-		}
-
-		let packet = {
-			address: path,
-			args: args,
-		}
-
-		if (this.debugToLogger) {
-			this.log('info', `Eos: Sending packet: ${JSON.stringify(packet)}`)
-		}
-
-		this.oscSocket.send(packet)
 	}
 
 	/*

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,4 +1,5 @@
 const { combineRgb } = require('@companion-module/base')
+const constants = require('./constants.js')
 
 module.exports = function (self) {
 	const presets = {
@@ -134,6 +135,7 @@ module.exports = function (self) {
 		},
 	}
 
+	// macro presets (with fire feedback)
 	const numLabels = typeof self.getNumLabelsToPoll === 'function' ? self.getNumLabelsToPoll() : constants.DEFAULT_NUM_LABELS
 
 	for (let i = 1; i <= numLabels; i++) {
@@ -176,6 +178,42 @@ module.exports = function (self) {
 		}
 	}
 
+	// // generic direct-select style presets
+	// // currently disabled until presets have more capabilities for creating localVariables
+	// // - can't currently create variables that are based on value feedbacks
+	// for (const item_type of ['macro', 'preset', 'group', 'ip', 'cp', 'fp', 'bp', 'fx', 'snap', 'ms']) {
+	// 	const item_name = constants.ITEM_NAMES[item_type];
+	// 	const action_id = item_type == 'macro' ? 'run_macro' : `ds_${item_type}`;
+	// 	presets[`ds_${item_type}`] = {
+	// 		type: 'button',
+	// 		name: `DS ${item_name}`,
+	// 		category: 'Direct Selects',
+	// 		style: {
+	// 			text: `$(local:label)`,
+	// 			size: '14',
+	// 			color: 0xffffff,
+	// 			bgcolor: constants.ITEM_COLOURS[item_type],
+	// 			show_topbar: false
+	// 		},
+	// 		feedbacks: [],
+	// 		steps: [{
+	// 			down: [{
+	// 				actionId: action_id,
+	// 				options: {
+	// 					[item_type]: { isExpression: true, value: '$(local:num)' },
+	// 				},
+	// 			}],
+	// 			up: [],
+	// 		}],
+	// 		localVariables: [
+	// 			{
+	// 				variableType: 'simple',
+	// 				variableName: 'num',
+	// 				startupValue: 1,
+	// 			},
+	// 		],
+	// 	}
+	// }
 
 	self.setPresetDefinitions(presets)
 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -53,7 +53,7 @@ class EosSync {
      */
     set_item_values(item_type, item_number, list_start_index, list_values) {        
         let label = get_list_param(2, list_start_index, list_values)
-        if (label) {
+        if (label !== undefined) {
             let subs = this[item_type].get(item_number)?.subscriptions ?? [];
 
             this[item_type].set(item_number, {

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,0 +1,134 @@
+const constants = require('./constants.js')
+
+/**
+ * 
+ * @param {number} param_index 
+ * @param {number} start_index 
+ * @param {{}[]} arguments 
+ * @returns {any|null}
+ */
+function get_list_param(param_index, start_index, arguments) {
+    if (start_index > param_index) return null;
+    let list_index = param_index - start_index;
+    if (list_index >= arguments.length) return null;
+
+    if (arguments[list_index] === undefined) {
+        return "sdfldsjf;asldfjkas;lfdkjas";
+    }
+
+    return arguments[list_index].value;
+}
+
+class EosSync {
+    constructor(parameters) {
+        for (const item_type of constants.LABEL_NAMES) {
+            this[item_type] = new Map();
+        }
+        
+        this.feedback_numbers = new Map();
+    }
+
+    /**
+     * Clear information about an item
+     * 
+     * We only clear the label here, so we keep the subscriptions and can use them when updating later
+     * 
+     * @param {string} item_type 
+     * @param {string} item_num 
+     */
+    set_item_deleted(item_type, item_number) {
+
+        let obj = this[item_type].get(item_number);
+        obj.label = undefined;
+        return obj.subscriptions ?? [];
+    }
+
+    /**
+     * 
+     * @param {string} item_type 
+     * @param {string} item_num 
+     * @param {number} list_start_index 
+     * @param {{}[]} list_values 
+     * @returns {string[]} list of feedback IDs subscribed to this thing
+     */
+    set_item_values(item_type, item_number, list_start_index, list_values) {        
+        let label = get_list_param(2, list_start_index, list_values)
+        if (label) {
+            let subs = this[item_type].get(item_number)?.subscriptions ?? [];
+
+            this[item_type].set(item_number, {
+                label: label,
+                subscriptions: subs
+            });
+
+            return subs;
+        }
+
+        return [];
+    }
+
+    /**
+     * 
+     * @param {string} item_type 
+     * @param {string} item_number 
+     * @param {string} feedback_id 
+     */
+    get_item_value(item_type, item_number, feedback_id) {
+        let prev_feedback_num = this.feedback_numbers.get(feedback_id);
+        if (prev_feedback_num !== undefined) {
+            if (prev_feedback_num != item_number) {
+                this.remove_item_subscription(item_type, prev_feedback_num, feedback_id);
+            }
+        }
+        this.feedback_numbers.set(feedback_id, item_number);
+
+        let item = this[item_type].get(item_number);
+
+        if (item === undefined) {
+            // not synced from Eos, we still store the subscriptions though
+            this[item_type].set(item_number, {
+                subscriptions: [feedback_id]
+            });
+            return '';
+        }
+
+        // register subscription ID
+        if (!item.subscriptions.includes(feedback_id)) {
+            item.subscriptions.push(feedback_id)
+        }
+
+        return item.label ?? '';
+    }
+
+    /**
+     * 
+     * @param {string} item_type 
+     * @param {string} item_number 
+     * @param {string} feedback_id 
+     * @returns 
+     */
+    remove_item_subscription(item_type, item_number, feedback_id) {
+        this.feedback_numbers.delete(feedback_id);
+        let item = this[item_type].get(item_number);
+
+        if (item === undefined) return;
+
+        const index = item.subscriptions.indexOf(feedback_id);
+        if (index > -1) {
+            item.subscriptions.splice(index, 1);
+        }
+    }
+
+    reset() {
+        for (const item_type of constants.LABEL_NAMES) {
+            let items = this[item_type];
+            // this also clears out all of our subscriptions
+            // however they will be re-registered next time the callback runs
+            items.clear();
+        }
+    }
+
+}
+
+module.exports.EosSync = EosSync
+module.exports.get_list_param = get_list_param


### PR DESCRIPTION
Redo the label system to sync all labels from Eos using count and index messages, then only use the labels we actually need.

The labels are available as value feedbacks, which allows selecting any label without us having to generate hundreds of variables, however I have kept the variables as well because the value feedbacks are a bit more complicated and and they can't be included in presets yet (they need to be added as a local variable to the button, then referenced elsewhere).

Added some direct-select style actions for each of the item types (for use in future presets).

Also fixed a minor issue with the colour hue/saturation when it is empty.

### Regarding the UIDs
These aren't really useful here, I believe they are intended for if you are saving and loading the sync data to disk and tracking items over a long period of time. Given we always base it off the item number anyway, there isn't much point complicating it with a UID.